### PR TITLE
Initial implementation

### DIFF
--- a/.github/workflows/telemetry.yaml
+++ b/.github/workflows/telemetry.yaml
@@ -6,7 +6,7 @@ jobs:
   telemetry:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-telemetry@initial_action
+    - uses: cloudposse/github-action-telemetry
       with:
         collector-endpoint: ${{ secrets.COLLECTOR_ENDPOINT }}
         collector-token: ${{ secrets.COLLECTOR_TOKEN }}

--- a/.github/workflows/telemetry.yaml
+++ b/.github/workflows/telemetry.yaml
@@ -6,7 +6,7 @@ jobs:
   telemetry:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-telemetry
+    - uses: cloudposse/github-action-telemetry@main
       with:
         collector-endpoint: ${{ secrets.COLLECTOR_ENDPOINT }}
         collector-token: ${{ secrets.COLLECTOR_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: cloudposse/github-action-telemetry@initial_action
+      shell: bash
       with:
         collector_endpoint: ${{ secrets.COLLECTOR_ENDPOINT }}
         collector_token: ${{ secrets.COLLECTOR_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: GitHub Telemetry
 on: pull_request
-    types: [edited, opened, reopened]
+  types: [edited, opened, reopened]
 jobs:
   telemetry:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 name: GitHub Telemetry
-on: pull_request
-  pull_request: [edited, opened, reopened]
+on:
+  pull_request:
+    types: [edited, opened, reopened]
 jobs:
   telemetry:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: GitHub Telemetry
 on: pull_request
-  types: [edited, opened, reopened]
+  pull_request: [edited, opened, reopened]
 jobs:
   telemetry:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: cloudposse/github-action-telemetry@initial_action
-      shell: bash
       with:
         collector_endpoint: ${{ secrets.COLLECTOR_ENDPOINT }}
         collector_token: ${{ secrets.COLLECTOR_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,12 @@
+name: GitHub Telemetry
+on: pull_request
+    types: [edited, opened, reopened]
+jobs:
+  telemetry:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: cloudposse/github-action-telemetry@initial_action
+      with:
+        collector_endpoint: ${{ secrets.COLLECTOR_ENDPOINT }}
+        collector_token: ${{ secrets.COLLECTOR_TOKEN }}
+        jira_keys: "CPCO,INTERNAL"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,6 @@ jobs:
     steps:
     - uses: cloudposse/github-action-telemetry@initial_action
       with:
-        collector_endpoint: ${{ secrets.COLLECTOR_ENDPOINT }}
-        collector_token: ${{ secrets.COLLECTOR_TOKEN }}
-        jira_keys: "CPCO,INTERNAL"
+        collector-endpoint: ${{ secrets.COLLECTOR_ENDPOINT }}
+        collector-token: ${{ secrets.COLLECTOR_TOKEN }}
+        jira-keys: "CPCO,INTERNAL"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: GitHub Telemetry
 on:
   pull_request:
-    types: [edited, opened, reopened]
+    types: [edited, opened, reopened, synchronize]
 jobs:
   telemetry:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Create a workflow file (e.g. `.github/workflows/github-telemetry.yml`) that cont
 ```yaml
 name: GitHub Telemetry
 on: pull_request
-
+    types: [opened]
 jobs:
   telemetry:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
   repo_name: // e.g. infra
   repo_url: // full URL to repo
   event_type: // github event type
-  jira_issues: [] // extracted from event payload
+  jira_tickets: [] // extracted from event payload
   pull_request { // if the event is a pull_request
     created_at:
     number:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ jobs:
 
 ## Payload Specification
 
-```
-
+```json
 {
   repo_org: // e.g. cloudposse
   repo_name: // e.g. infra

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ When triggered by a GitHub API event, this action will scrape the event for all 
 Create a workflow file (e.g. `.github/workflows/github-telemetry.yml`) that contains a step that `uses: cloudposse/github-action-telemetry@v1.0.0`. Here's an example workflow file:
 
 ```yaml
-name: Gather Telemetry
+name: GitHub Telemetry
 on: pull_request
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ jobs:
 
 ## Use-case
 
-This event could facilitate automatic annotation of JIRA tickets based on the contents of GitHub pull requests, to improve task tracking between these two platforms. Other integration routes certainly exist.
+This event could facilitate automatic annotation of JIRA tickets based on the contents of GitHub pull requests, to improve task tracking between these two platforms when using the native Jira GitHub interaction is not an option.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
-# github-action-telemetry
-GitHub Action for telemetry harvesting from repos
+# Telemetry Gathering GitHub Action
+
+**Name:** `cloudposse/github-action-telemetry`
+
+When triggered by a GitHub API event, this action will scrape the event for all JIRA tickets mentioned and an assortment of relevant metadata.
+
+## Usage instructions
+
+Create a workflow file (e.g. `.github/workflows/telemetry-gathering.yml`) that contains a step that `uses: cloudposse/github-action-telemetry@v1.0.0`. Here's an example workflow file:
+
+```yaml
+name: Gather Telemetry
+on: pull_request
+
+jobs:
+  telemetry:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: cloudposse/github-action-telemetry@v1.0.0
+      with:
+        collector_endpoint: "https://awesome-endpoint.net"
+        collector_token: ${{ secrets.token }}
+        jira_keys: "INTERNAL,EXTERNAL,CLOUDPOSSE"
+
+```
+
+## Inputs
+
+- `collector_endpoint`: This is the HTTP(S) address of a webhook that is expecting POST payloads that conform to the specifications in the next section.
+- `collector_token`: This is an optional token the will be passed in a `token=` header attached to the HTTP POST payload sent to the `collector_endpoint`.
+- `jira_keys`: This is a comma-separated, (space-free) list of JIRA codes to look for in the GitHub event JSON. For example, if `jira_keys: "INTERNAL"`, then `cloudposse/github-action-telemetry` will extract all strings matching the regular expression `\bINTERNAL-\d+` from the GitHub event JSON.
+
+## Payload Specification
+
+```
+
+{
+  repo_org: // e.g. cloudposse
+  repo_name: // e.g. infra
+  repo_url: // full URL to repo
+  event_type: // github event type
+  jira_issues: [] // extracted from event payload
+  pull_request { // if the event is a pull_request
+    created_at:
+    number:
+    url:
+    title:
+    author:
+    description:
+  }
+}
+
+```
+
+## Why?
+
+This event could facilitate automatic annotation of JIRA tickets based on the contents of GitHub pull requests, to improve task tracking between these two platforms. Other integration routes certainly exist.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ When triggered by a GitHub API event, this action will scrape the event for all 
 
 ## Usage instructions
 
-Create a workflow file (e.g. `.github/workflows/telemetry-gathering.yml`) that contains a step that `uses: cloudposse/github-action-telemetry@v1.0.0`. Here's an example workflow file:
+Create a workflow file (e.g. `.github/workflows/github-telemetry.yml`) that contains a step that `uses: cloudposse/github-action-telemetry@v1.0.0`. Here's an example workflow file:
 
 ```yaml
 name: Gather Telemetry

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Name:** `cloudposse/github-action-telemetry`
 
-When triggered by a GitHub API event, this action will scrape the event for all JIRA tickets mentioned and an assortment of relevant metadata.
+This GitHub Action will scrape the event for JIRA tickets and an assortment of relevant metadata and post it to a webhook endpoint
 
 ## Usage instructions
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
       with:
         collector_endpoint: "https://awesome-endpoint.net"
         collector_token: ${{ secrets.token }}
-        jira_keys: "INTERNAL,EXTERNAL,CLOUDPOSSE"
+        jira_keys: "DEV,OPS,SECOPS,IT"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ jobs:
 
 ```
 
-## Why?
+## Use-case
 
 This event could facilitate automatic annotation of JIRA tickets based on the contents of GitHub pull requests, to improve task tracking between these two platforms. Other integration routes certainly exist.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Telemetry Gathering GitHub Action
+# GitHub Action for Telemetry
 
 **Name:** `cloudposse/github-action-telemetry`
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,32 @@
+name: 'Telemetry Gathering'
+description: 'Extract all relevant JIRA tickets from a given GitHub event payload and write those values to a user-specified webhook endpoint.'
+inputs:
+  collector-endpoint:
+    description: "A webhook to receive the Jira ticket-containing payload"
+    required: true
+  collector-token:
+    description: "Token used to authenticate GitHub Action to the webhook endpoint"
+    required: true
+  jira-keys:
+    description: "Prefixes to search for in Jira tickets"
+    required: true
+  event:
+    description: "GitHub API payload for this event"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: "Setup Python"
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.x"
+    - name: "Install Necessary Package"
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests
+    - name: "Send Payload"
+      shell: bash
+      run: python ./github/telemetry-gathering/send_webhook_payload.py
+branding:
+  icon: 'target'
+  color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Cloud Posse GitHub Telemetry'
 description: |
-  This action extracts all relevant JIRA tickets from a given GitHub event and posts the found tickets, along with some metadata, to a user-specified webhook endpoint.'
+  This action extracts all relevant JIRA tickets from a given GitHub event and posts the found tickets, along with some metadata, to a user-specified webhook endpoint.
 inputs:
   collector-endpoint:
     description: "A webhook to receive the Jira ticket-containing payload"

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,9 @@ runs:
       run: python ${{ github.action_path }}/send_webhook_payload.py
       env:
         INPUT_EVENT: ${{ toJson(github.event) }}
-        #INPUT_EVENT: ${{ steps.event-dump.outputs.event }}
+        INPUT_COLLECTOR_ENDPOINT: ${{ env.INPUT_COLLECTOR_ENDPOINT }}
+        INPUT_COLLECTOR_TOKEN: ${{ env.INPUT_COLLECTOR_TOKEN }}
+        INPUT_JIRA_KEYS: ${{ env.INPUT_JIRA_KEYS }}
 branding:
   icon: 'target'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Telemetry Gathering'
+name: 'Cloud Posse GitHub Telemetry'
 description: |
   Cloud Posse uses this action to help us keep track of activity pertaining to repository events and associating it with Jira. This action extracts all relevant Jira tickets from a given GitHub event payload and posts the values to a user-specified webhook endpoint.'
 inputs:

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,7 @@ runs:
 #        echo "::set-output name=event::$GITHUB_EVENT"
     - name: "Send Payload"
       shell: bash
+      workdir: ${{ github.action_path }}
       run: python send_webhook_payload.py
       env:
         INPUT_EVENT: ${{ toJson(github.event) }}

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,12 @@ runs:
       with:
         python-version: "3.x"
     - name: "Install Necessary Package"
+      shell: bash
       run: |
         python -m pip install --upgrade pip
         pip install requests
     - name: "Capture Triggering GitHub API Event"
+      shell: bash
       id: event-dump
       env:
         GITHUB_EVENT: ${{ toJson(github.event) }}

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         pip install requests
     - name: "Send Payload"
       shell: bash
-      run: python ./github/telemetry-gathering/send_webhook_payload.py
+      run: python send_webhook_payload.py
 branding:
   icon: 'target'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,9 @@ runs:
       run: python ${{ github.action_path }}/send_webhook_payload.py
       env:
         INPUT_EVENT: ${{ toJson(github.event) }}
-        INPUT_COLLECTOR_ENDPOINT: ${{ env.INPUT_COLLECTOR_ENDPOINT }}
-        INPUT_COLLECTOR_TOKEN: ${{ env.INPUT_COLLECTOR_TOKEN }}
-        INPUT_JIRA_KEYS: ${{ env.INPUT_JIRA_KEYS }}
+        INPUT_COLLECTOR_ENDPOINT: ${{ inputs.collector-endpoint }}
+        INPUT_COLLECTOR_TOKEN: ${{ inputs.collector-token }}
+        INPUT_JIRA_KEYS: ${{ inputs.jira-keys }}
 branding:
   icon: 'target'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ runs:
 #      run: |
 #        echo "::set-output name=event::$GITHUB_EVENT"
     - name: "Send Payload"
-      shell: python
-      run: ${{ github.action_path }}/send_webhook_payload.py
+      shell: bash
+      run: python ${{ github.action_path }}/send_webhook_payload.py
       env:
         INPUT_EVENT: ${{ toJson(github.event) }}
         #INPUT_EVENT: ${{ steps.event-dump.outputs.event }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Cloud Posse GitHub Telemetry'
 description: |
-  Cloud Posse uses this action to help us keep track of activity pertaining to repository events and associating it with Jira. This action extracts all relevant Jira tickets from a given GitHub event payload and posts the values to a user-specified webhook endpoint.'
+  This action extracts all relevant JIRA tickets from a given GitHub event and posts the found tickets, along with some metadata, to a user-specified webhook endpoint.'
 inputs:
   collector-endpoint:
     description: "A webhook to receive the Jira ticket-containing payload"
@@ -10,9 +10,6 @@ inputs:
     required: true
   jira-keys:
     description: "Prefixes to search for in Jira tickets"
-    required: true
-  event:
-    description: "GitHub API payload for this event"
     required: true
 runs:
   using: "composite"
@@ -25,9 +22,17 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install requests
+    - name: "Capture Triggering GitHub API Event"
+      id: event-dump
+      env:
+        GITHUB_EVENT: ${{ toJson(github.event) }}
+      run: |
+        echo "::set-output name=event::$GITHUB_EVENT"
     - name: "Send Payload"
       shell: bash
       run: python send_webhook_payload.py
+      with:
+        event: ${{ steps.event-dump.outputs.event }}
 branding:
   icon: 'target'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -23,18 +23,19 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install requests
-    - name: "Capture Triggering GitHub API Event"
-      shell: bash
-      id: event-dump
-      env:
-        GITHUB_EVENT: ${{ toJson(github.event) }}
-      run: |
-        echo "::set-output name=event::$GITHUB_EVENT"
+#    - name: "Capture Triggering GitHub API Event"
+#      shell: bash
+#      id: event-dump
+#      env:
+#        GITHUB_EVENT: ${{ toJson(github.event) }}
+#      run: |
+#        echo "::set-output name=event::$GITHUB_EVENT"
     - name: "Send Payload"
       shell: bash
       run: python send_webhook_payload.py
-      with:
-        event: ${{ steps.event-dump.outputs.event }}
+      env:
+        INPUT_EVENT: ${{ toJson(github.event) }}
+        #INPUT_EVENT: ${{ steps.event-dump.outputs.event }}
 branding:
   icon: 'target'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -31,9 +31,8 @@ runs:
 #      run: |
 #        echo "::set-output name=event::$GITHUB_EVENT"
     - name: "Send Payload"
-      shell: bash
-      workdir: ${{ github.action_path }}
-      run: python send_webhook_payload.py
+      shell: python
+      run: ${{ github.action_path }}/send_webhook_payload.py
       env:
         INPUT_EVENT: ${{ toJson(github.event) }}
         #INPUT_EVENT: ${{ steps.event-dump.outputs.event }}

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
   collector-token:
     description: "Token used to authenticate GitHub Action to the webhook endpoint"
-    required: true
+    required: false
   jira-keys:
     description: "Prefixes to search for in Jira tickets"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
 name: 'Telemetry Gathering'
-description: 'Extract all relevant JIRA tickets from a given GitHub event payload and write those values to a user-specified webhook endpoint.'
+description: |
+  Cloud Posse uses this action to help us keep track of activity pertaining to repository events and associating it with Jira. This action extracts all relevant Jira tickets from a given GitHub event payload and posts the values to a user-specified webhook endpoint.'
 inputs:
   collector-endpoint:
     description: "A webhook to receive the Jira ticket-containing payload"

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -67,6 +67,7 @@ if __name__ == '__main__':
     if "pull_request" in event_json.keys():
         payload['pull_request'] = get_pull_request_info(event_json)
         payload['event_type'] = "pull_request"
+        payload['event_action'] = event_json["action"]
     else:
         type_specific_info = {}
         payload['event_type'] = "unsupported"

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     print(f"event: {event}")
     jira_tickets = []
     for key in jira_keys.split(","):
-        regex_string = r"(\b|\\n|\\r){}-\d+".format(key)
+        regex_string = r"(?<=\W|[a-z]){}-\d+".format(key)
         print(f"regex: {regex_string}")
         matches = re.findall(regex_string, event)
         if matches:

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -44,6 +44,7 @@ if __name__ == '__main__':
     jira_tickets = []
     for key in jira_keys.split(","):
         regex_string = r"\b" + key + r"-\d+"
+        print(f"regex: {regex_string}")
         matches = re.findall(regex_string, event)
         if matches:
             jira_tickets.append(matches)

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     # extract all JIRA tickets
     jira_tickets = []
     for key in jira_keys.split(","):
-        regex_string = r"\b" + key + r"-\d+"
+        regex_string = r"\b{}-\d+".format(key)
         print(f"regex: {regex_string}")
         matches = re.findall(regex_string, event)
         if matches:

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -71,6 +71,7 @@ if __name__ == '__main__':
         payload['event_type'] = "unsupported"
 
     # send payload
+    print(f"Payload: {json.dumps(payload, indent=4)}")
     headers = {}
     headers['user-agent'] = "cloudposse/github-action-telemetry"
     if collector_token:

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -17,7 +17,7 @@ import requests
 def get_pull_request_info(event_json):
     pull_request_info = {}
     pull_request_info['number'] = event_json["pull_request"]["number"]
-    pull_request_info['url'] = event_json["pull_request"]["url"]
+    pull_request_info['url'] = event_json["pull_request"]["_links"]["html"]["href"]
     pull_request_info['title'] = event_json["pull_request"]["title"]
     pull_request_info['created_at'] = event_json["pull_request"]["created_at"]
     pull_request_info['description'] = event_json["pull_request"]["body"]

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -41,8 +41,6 @@ if __name__ == '__main__':
         raise ValueError("Because one or more inputs is null-valued, this program is termiating.")
 
     # extract all JIRA tickets
-    print(f"event type: {type(event)}")
-    print(f"event: {event}")
     jira_tickets = []
     for key in jira_keys.split(","):
         regex_string = r"(?<=\W|[a-z]){}-\d+".format(key)

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
         raise ValueError("Because one or more inputs is null-valued, this program is termiating.")
 
     # extract all JIRA tickets
+    print(f"event: {event}")
     jira_tickets = []
     for key in jira_keys.split(","):
         regex_string = r"\b{}-\d+".format(key)

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -31,11 +31,9 @@ if __name__ == '__main__':
     collector_token = os.environ['INPUT_COLLECTOR_TOKEN']
     jira_keys = os.environ['INPUT_JIRA_KEYS']
     event = os.environ['INPUT_EVENT']
-    if collector_endpoint == "" or collector_token == "" or jira_keys == "" or event == "":
+    if collector_endpoint == "" or jira_keys == "" or event == "":
         if collector_endpoint == "":
             print("collector_endpoint input is null-valued.")
-        if collector_token == "":
-            print("collector_token input is null-valued.")
         if jira_keys == "":
             print("jira_keys input is null-valued.")
         if event == "":

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
 
     # send payload
     headers = {}
-    headers['user-agent'] = payload["repo_org"] + "/" + payload["repo_name"]
+    headers['user-agent'] = "cloudposse/github-action-telemetry"
     if collector_token:
         headers['token'] = collector_token
         response = requests.post(collector_endpoint, headers=headers, data=json.dumps(payload))

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
         raise ValueError("Because one or more inputs is null-valued, this program is termiating.")
 
     # extract all JIRA tickets
+    print(f"event type: {type(event)}")
     print(f"event: {event}")
     jira_tickets = []
     for key in jira_keys.split(","):

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     print(f"event: {event}")
     jira_tickets = []
     for key in jira_keys.split(","):
-        regex_string = r"\b{}-\d+".format(key)
+        regex_string = r"(\b|\\n|\\r){}-\d+".format(key)
         print(f"regex: {regex_string}")
         matches = re.findall(regex_string, event)
         if matches:

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -2,10 +2,10 @@
 # This action extracts metadata from a GitHub Actions event and sends it via HTTP to a database.
 # Note: For now, this action only supports pull request events.
 # Inputs:
-# collector_endpoint: ${{ inputs.collector-endpoint }}
-# collector_token: ${{ inputs.collector-token }}
-# jira_keys: ${{ inputs.jira-keys }}
-# event: ${{ inputs.event }}
+# os.environ['INPUT_COLLECTOR_ENDPOINT']
+# os.environ['INPUT_COLLECTOR_TOKEN']
+# os.environ['INPUT_JIRA_KEYS']
+# os.environ['INPUT_EVENT']
 
 # imports
 import json
@@ -13,61 +13,56 @@ import os
 import re
 import requests
 
-# read in env vars
-collector_endpoint = os.environ['INPUT_COLLECTOR_ENDPOINT']
-collector_token = os.environ['INPUT_COLLECTOR_TOKEN']
-jira_keys = os.environ['INPUT_JIRA_KEYS']
-event = os.environ['INPUT_EVENT']
-
-# extract all JIRA tickets
-jira_tickets = []
-for key in jira_keys.split(","):
-    regex_string = key + "-\d+"
-    matches = re.findall(regex_string, event)
-    if matches:
-        jira_tickets.append(matches)
-# flatten list of lists, if needed
-all_jira_tickets = [item for sublist in jira_tickets for item in sublist]
-
-# read in event data into json for remaining queries
-event_json = json.loads(event)
-print(event_json["pull_request"].keys())
-print(event_json["pull_request"]["number"])
-print(event_json["pull_request"]["url"])
-print(event_json["pull_request"]["title"])
-print(event_json["pull_request"]["created_at"])
-
-# if event is a pull request, extract pull request-specific information
-pull_request_determination = "pull_request" in event_json.keys()
-if pull_request_determination:
+def get_pull_request_info(event_json):
     pull_request_info = {}
     pull_request_info['number'] = event_json["pull_request"]["number"]
     pull_request_info['url'] = event_json["pull_request"]["url"] 
     pull_request_info['title'] = event_json["pull_request"]["title"]
     pull_request_info['created_at'] = event_json["pull_request"]["created_at"]
-    #pull_request_info['description'] = 
-    event_type = "pull_request"
-else:
-    event_type = "unknown"
+    pull_request_info['description'] = event_json["pull_request"]["body"]
+    pull_request_info['author'] = event_json["pull_request"]["user"]["login"]
+    return pull_request_info
 
-# construct payload
-payload = {}
-payload['repo_org'] = event_json["repository"]["full_name"].split("/")[0]
-payload['repo_name'] = event_json["repository"]["name"]
-payload['repo_url'] = event_json["repository"]["html_url"]
-payload['jira_issues'] = all_jira_tickets
-payload['event_type'] = event_type
-if pull_request_determination:
-    payload['pull_request'] = pull_request_info
-print(f"type of payload['pull_request']: {type(payload['pull_request'])}")
-print(f"type of payload['event_type']: {type(payload['event_type'])}")
+if __name__=='__main__':
+    # read in env vars
+    collector_endpoint = os.environ['INPUT_COLLECTOR_ENDPOINT']
+    collector_token = os.environ['INPUT_COLLECTOR_TOKEN']
+    jira_keys = os.environ['INPUT_JIRA_KEYS']
+    event = os.environ['INPUT_EVENT']
 
-# send payload
-print(collector_endpoint)
-if collector_token:
-    response = requests.post(collector_endpoint, headers = {"token": collector_token}, data = json.dumps(payload))
-else:
-    response = requests.post(collector_endpoint, data = json.dumps(payload))
-# check response
-print(f"Response code: {response.status_code}")
-response.raise_for_status()
+    # extract all JIRA tickets
+    jira_tickets = []
+    for key in jira_keys.split(","):
+        regex_string = "\b" + key + "-\d+"
+        matches = re.findall(regex_string, event)
+        if matches:
+            jira_tickets.append(matches)
+    # flatten list of lists, if needed
+    all_jira_tickets = [item for sublist in jira_tickets for item in sublist]
+
+    # read in event data into json for remaining queries
+    event_json = json.loads(event)
+
+    # construct payload
+    ## extract general metadata
+    payload = {}
+    payload['repo_org'] = event_json["repository"]["full_name"].split("/")[0]
+    payload['repo_name'] = event_json["repository"]["name"]
+    payload['repo_url'] = event_json["repository"]["html_url"]
+    payload['jira_issues'] = all_jira_tickets
+    ## extract event type-specific information
+    if "pull_request" in event_json.keys():
+        payload['pull_request'] = get_pull_request_info(event_json)
+        payload['event_type'] = "pull_request"
+    else:
+        type_specific_info = {}
+        payload['event_type'] = "unknown"
+
+    # send payload
+    if collector_token:
+        response = requests.post(collector_endpoint, headers = {"token": collector_token}, data = json.dumps(payload))
+    else:
+        response = requests.post(collector_endpoint, data = json.dumps(payload))
+    # check response
+    print(f"Response code: {response.status_code}")
+    response.raise_for_status()

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -49,8 +49,9 @@ if __name__ == '__main__':
         matches = re.findall(regex_string, event)
         if matches:
             jira_tickets.append(matches)
-    # flatten list of lists, if needed
+    # flatten lists and deduplicate entries, if needed
     all_jira_tickets = [item for sublist in jira_tickets for item in sublist]
+    all_jira_tickets = list(set(all_jira_tickets))
 
     # read in event data into json for remaining queries
     event_json = json.loads(event)

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -1,0 +1,73 @@
+# send_webhook_payload.py
+# This action extracts metadata from a GitHub Actions event and sends it via HTTP to a database.
+# Note: For now, this action only supports pull request events.
+# Inputs:
+# collector_endpoint: ${{ inputs.collector-endpoint }}
+# collector_token: ${{ inputs.collector-token }}
+# jira_keys: ${{ inputs.jira-keys }}
+# event: ${{ inputs.event }}
+
+# imports
+import json
+import os
+import re
+import requests
+
+# read in env vars
+collector_endpoint = os.environ['INPUT_COLLECTOR_ENDPOINT']
+collector_token = os.environ['INPUT_COLLECTOR_TOKEN']
+jira_keys = os.environ['INPUT_JIRA_KEYS']
+event = os.environ['INPUT_EVENT']
+
+# extract all JIRA tickets
+jira_tickets = []
+for key in jira_keys.split(","):
+    regex_string = key + "-\d+"
+    matches = re.findall(regex_string, event)
+    if matches:
+        jira_tickets.append(matches)
+# flatten list of lists, if needed
+all_jira_tickets = [item for sublist in jira_tickets for item in sublist]
+
+# read in event data into json for remaining queries
+event_json = json.loads(event)
+print(event_json["pull_request"].keys())
+print(event_json["pull_request"]["number"])
+print(event_json["pull_request"]["url"])
+print(event_json["pull_request"]["title"])
+print(event_json["pull_request"]["created_at"])
+
+# if event is a pull request, extract pull request-specific information
+pull_request_determination = "pull_request" in event_json.keys()
+if pull_request_determination:
+    pull_request_info = {}
+    pull_request_info['number'] = event_json["pull_request"]["number"]
+    pull_request_info['url'] = event_json["pull_request"]["url"] 
+    pull_request_info['title'] = event_json["pull_request"]["title"]
+    pull_request_info['created_at'] = event_json["pull_request"]["created_at"]
+    #pull_request_info['description'] = 
+    event_type = "pull_request"
+else:
+    event_type = "unknown"
+
+# construct payload
+payload = {}
+payload['repo_org'] = event_json["repository"]["full_name"].split("/")[0]
+payload['repo_name'] = event_json["repository"]["name"]
+payload['repo_url'] = event_json["repository"]["html_url"]
+payload['jira_issues'] = all_jira_tickets
+payload['event_type'] = event_type
+if pull_request_determination:
+    payload['pull_request'] = pull_request_info
+print(f"type of payload['pull_request']: {type(payload['pull_request'])}")
+print(f"type of payload['event_type']: {type(payload['event_type'])}")
+
+# send payload
+print(collector_endpoint)
+if collector_token:
+    response = requests.post(collector_endpoint, headers = {"token": collector_token}, data = json.dumps(payload))
+else:
+    response = requests.post(collector_endpoint, data = json.dumps(payload))
+# check response
+print(f"Response code: {response.status_code}")
+response.raise_for_status()

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -49,14 +49,14 @@ if __name__=='__main__':
     payload['repo_org'] = event_json["repository"]["full_name"].split("/")[0]
     payload['repo_name'] = event_json["repository"]["name"]
     payload['repo_url'] = event_json["repository"]["html_url"]
-    payload['jira_issues'] = all_jira_tickets
+    payload['jira_tickets'] = all_jira_tickets
     ## extract event type-specific information
     if "pull_request" in event_json.keys():
         payload['pull_request'] = get_pull_request_info(event_json)
         payload['event_type'] = "pull_request"
     else:
         type_specific_info = {}
-        payload['event_type'] = "unknown"
+        payload['event_type'] = "unsupported"
 
     # send payload
     if collector_token:

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -31,6 +31,12 @@ if __name__ == '__main__':
     collector_token = os.environ['INPUT_COLLECTOR_TOKEN']
     jira_keys = os.environ['INPUT_JIRA_KEYS']
     event = os.environ['INPUT_EVENT']
+    if collector_endpoint == "" or collector_token == "" or jira_keys == "" or event == "":
+        print(f"collector_endpoint: {collector_endpoint}")
+        print(f"collector_token: {collector_token}")
+        print(f"jira_keys: {jira_keys}")
+        print(f"event: {event}")
+        raise ValueError("None of the inputs should be null.")
 
     # extract all JIRA tickets
     jira_tickets = []

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -75,9 +75,9 @@ if __name__ == '__main__':
     headers['user-agent'] = "cloudposse/github-action-telemetry"
     if collector_token:
         headers['token'] = collector_token
-        response = requests.post(collector_endpoint, headers=headers, data=json.dumps(payload))
+        response = requests.post(collector_endpoint, headers=headers, json=payload)
     else:
-        response = requests.post(collector_endpoint, headers=headers, data=json.dumps(payload))
+        response = requests.post(collector_endpoint, headers=headers, json=payload)
     # check response
     print(f"Response code: {response.status_code}")
     response.raise_for_status()

--- a/send_webhook_payload.py
+++ b/send_webhook_payload.py
@@ -32,11 +32,15 @@ if __name__ == '__main__':
     jira_keys = os.environ['INPUT_JIRA_KEYS']
     event = os.environ['INPUT_EVENT']
     if collector_endpoint == "" or collector_token == "" or jira_keys == "" or event == "":
-        print(f"collector_endpoint: {collector_endpoint}")
-        print(f"collector_token: {collector_token}")
-        print(f"jira_keys: {jira_keys}")
-        print(f"event: {event}")
-        raise ValueError("None of the inputs should be null.")
+        if collector_endpoint == "":
+            print("collector_endpoint input is null-valued.")
+        if collector_token == "":
+            print("collector_token input is null-valued.")
+        if jira_keys == "":
+            print("jira_keys input is null-valued.")
+        if event == "":
+            print("event input is null-valued.")
+        raise ValueError("Because one or more inputs is null-valued, this program is termiating.")
 
     # extract all JIRA tickets
     jira_tickets = []


### PR DESCRIPTION
## Description

Adding a new GitHub Action that will scrape JIRA issue mentions from a GitHub API event and then POST that data to an optionally token-protected collector webhook. (It also scrapes some metadata for use in organizing data in the collector.)

## Reference

CPCO-544

## TODO
- [x] Add README
- [x] ~~Support non-pull request events?~~
- [x] Test token-protected collector functionality