### PR TITLE
Replace Makefile with atmos.yaml

### DIFF
--- a/atmos.yaml
+++ b/atmos.yaml
@@ -1,0 +1,2 @@
+import:
+  - https://raw.githubusercontent.com/cloudposse/.github/refs/heads/main/.github/atmos/github-action.yaml


### PR DESCRIPTION
## what
- Remove `Makefile`
- Add `atmos.yaml`

## why
- Replace `build-harness` with `atmos` for readme genration

## References
* DEV-3229 Migrate from build-harness to atmos
